### PR TITLE
Pass optional destination parameter to create_lead

### DIFF
--- a/lib/lead_router/client.rb
+++ b/lib/lead_router/client.rb
@@ -9,9 +9,10 @@ module LeadRouter
       @token = token
     end
 
-    def create_lead(site_uuid, lead)
+    def create_lead(site_uuid, lead, destination=nil)
       require_arg "site_uuid", site_uuid
-      request :post, "https://#{@host}/rest/sites/#{site_uuid}/leads", lead.to_json
+      dest_headers = destination ? {"X-ROUTER-DESTINATIONS" => destination} : nil
+      request :post, "https://#{@host}/rest/sites/#{site_uuid}/leads", lead.to_json, dest_headers
     end
 
     def update_lead(site_uuid, lead_uuid, lead)
@@ -57,12 +58,14 @@ module LeadRouter
 
     private
 
-    def request(method, url, body)
+    def request(method, url, body, headers={})
+      headers.merge!({content_type: 'application/json', user_agent: "LeadRouterRuby/#{VERSION}"})
+
       RestClient::Request.execute(
         :method => method,
         :url => url,
         :payload => body,
-        :headers => {content_type: 'application/json', user_agent: "LeadRouterRuby/#{VERSION}"},
+        :headers => headers,
         :user => @user,
         :password => @token
       )

--- a/lib/lead_router/client.rb
+++ b/lib/lead_router/client.rb
@@ -9,9 +9,9 @@ module LeadRouter
       @token = token
     end
 
-    def create_lead(site_uuid, lead, destination=nil)
+    def create_lead(site_uuid, lead, destinations=[])
       require_arg "site_uuid", site_uuid
-      dest_headers = destination ? {"X-ROUTER-DESTINATIONS" => destination} : nil
+      dest_headers = destinations.empty? ? nil : { "X-ROUTER-DESTINATIONS" => destinations.join(",") }
       request :post, "https://#{@host}/rest/sites/#{site_uuid}/leads", lead.to_json, dest_headers
     end
 

--- a/test/test_lead_router.rb
+++ b/test/test_lead_router.rb
@@ -16,9 +16,17 @@ class LeadRouterTest < Minitest::Test
 
   def test_create_lead
     client.expects(:request).with(:post, 'https://api.com/rest/sites/site-123/leads',
-                                  '{"email":"lead@gmail.com"}')
+                                  '{"email":"lead@gmail.com"}', nil)
 
     client.create_lead("site-123", {email: "lead@gmail.com"})
+  end
+
+  def test_create_lead_manual_destination
+    client.expects(:request).with(:post, 'https://api.com/rest/sites/site-123/leads',
+                                  '{"email":"lead@gmail.com"}',
+                                  {"X-ROUTER-DESTINATIONS" => "wibble"})
+
+    client.create_lead("site-123", {email: "lead@gmail.com"}, "wibble")
   end
 
   def test_update_lead

--- a/test/test_lead_router.rb
+++ b/test/test_lead_router.rb
@@ -26,7 +26,15 @@ class LeadRouterTest < Minitest::Test
                                   '{"email":"lead@gmail.com"}',
                                   {"X-ROUTER-DESTINATIONS" => "wibble"})
 
-    client.create_lead("site-123", {email: "lead@gmail.com"}, "wibble")
+    client.create_lead("site-123", {email: "lead@gmail.com"}, ["wibble"])
+  end
+
+  def test_create_lead_for_multiple_destination
+    client.expects(:request).with(:post, 'https://api.com/rest/sites/site-123/leads',
+                                  '{"email":"lead@gmail.com"}',
+                                  {"X-ROUTER-DESTINATIONS" => "wibble,wobble"})
+
+    client.create_lead("site-123", {email: "lead@gmail.com"}, ["wibble", "wobble"])
   end
 
   def test_update_lead


### PR DESCRIPTION
This is to support manual destinations as per our notes from Realgeeks/lead_manager#1403

Let me know if we overlooked anything.