### PR TITLE
bug: [sc-35840] Use https for delete user. Bump version

### DIFF
--- a/lib/lead_router/client.rb
+++ b/lib/lead_router/client.rb
@@ -62,7 +62,7 @@ module LeadRouter
     # Only the lead manager is allowed to send this request, every other
     # client will get 403
     def delete_user(site_uuid, user_id)
-      request :delete, "http://#{@host}/rest/sites/#{site_uuid}/users/#{user_id}"
+      request :delete, "https://#{@host}/rest/sites/#{site_uuid}/users/#{user_id}"
     end
 
     private

--- a/lib/lead_router/version.rb
+++ b/lib/lead_router/version.rb
@@ -1,3 +1,3 @@
 module LeadRouter
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/test/test_lead_router.rb
+++ b/test/test_lead_router.rb
@@ -76,7 +76,7 @@ class LeadRouterTest < Minitest::Test
   end
 
   def test_delete_user
-    client.expects(:request).with(:delete, "http://api.com/rest/sites/site-123/users/1234")
+    client.expects(:request).with(:delete, "https://api.com/rest/sites/site-123/users/1234")
 
     client.delete_user("site-123", "1234")
   end


### PR DESCRIPTION
Story Details: https://app.shortcut.com/realgeekshq/story/35840/bug-agent-list-includes-removed-users-no-longer-with-the-company

This PR corrects the path for delete user calls to LR to be https instead of http. This is likely what is causing the 308 redirects. None of the other paths use http.